### PR TITLE
Allow Garden to dispatch CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: ['main']
   pull_request:
     branches: ['main']
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
Garden evaluates maintenance PRs by dispatching the repository CI workflow. Add the missing workflow_dispatch trigger so those evaluations no longer fail with GitHub API 422.

Validation: actionlint; CodeRabbit review clean.